### PR TITLE
Fix broken H1 heading in WhySquid.md

### DIFF
--- a/docs/WhySquid.md
+++ b/docs/WhySquid.md
@@ -27,7 +27,7 @@ contents, and also possibly perform request filtering to enhance the
 web applications' security. It can also be used as an IPv4-IPv6 (or
 v6-v4) gateway.
 
-#Why should I use Squid?
+# Why should I use Squid?
 
 [Squid](/SquidFaq/AboutSquid)
 is one of the most used HTTP proxy implementations, and can be deployed


### PR DESCRIPTION
Tiny PR, I know :)

There's a missing space after a MarkDown H1 header on the `WhySquid.md` page (one of the first ones that someone would see), causing the generated header to break as well:

![image](https://user-images.githubusercontent.com/25614522/214870203-94a6c337-5fd2-46a7-9680-9871af0d2043.png)

I checked the rest of the repo, and no additional MarkDown errors like this one seem to be present.