### PR TITLE
Add an external link to Raspberry PI tutorial

### DIFF
--- a/docs/ExternalLinks.md
+++ b/docs/ExternalLinks.md
@@ -1,6 +1,6 @@
 ---
 ---
-# External resoruces and links
+# External resources and links
 
 Here go resources to external sites which might be of interest to
 developers and users.

--- a/docs/ExternalLinks.md
+++ b/docs/ExternalLinks.md
@@ -11,6 +11,9 @@ developers and users.
 :   An introductory article by Kent Tong to core proxy and
     reverse-proxy concepts, with some clear examples for squid
 
+- [How to Setup a Proxy Server with Squid and Raspberry PI](https://peppe8o.com/setup-a-proxy-server-with-raspberry-pi-os-lite-and-squid/)
+:   Giuseppe Cassibba shows how to install Squid on Raspberry PI.
+
 ## For developers
 
 - <http://blogs.msdn.com/ie/archive/2005/10/22/483795.aspx>

--- a/docs/ExternalLinks.md
+++ b/docs/ExternalLinks.md
@@ -2,8 +2,7 @@
 ---
 # External resources and links
 
-Here go resources to external sites which might be of interest to
-developers and users.
+These external sites may be of interest to developers and users.
 
 ## Introductory
 


### PR DESCRIPTION
Also fixed page title spelling and polished page description.
