### PR TITLE
Fix c-icap configuration example to add missing acl "all"

### DIFF
--- a/docs/ConfigExamples/ContentAdaptation/C-ICAP.md
+++ b/docs/ConfigExamples/ContentAdaptation/C-ICAP.md
@@ -57,6 +57,7 @@ Edit c-icap.conf as follows:
     ServicesDir /usr/local/lib/c_icap
     LoadMagicFile /usr/local/etc/c-icap.magic
 
+    acl all src 0.0.0.0/0.0.0.0
     acl localhost src 127.0.0.1/255.255.255.255
     acl PERMIT_REQUESTS type REQMOD RESPMOD
     icap_access allow localhost PERMIT_REQUESTS


### PR DESCRIPTION
Without this "all" ACL definition in the c-icap.conf file, c-icap
reports a fatal error when starting up:

    The acl spec all does not exists!
    The required acl spec 'all' is missing
    Fatal error while parsing config file: ... 
        The line is: icap_access deny all

This definition for the "all" ACL comes from the example in c-icap
server configuration file:
https://github.com/c-icap/c-icap-server/blob/C_ICAP_0.6.3/c-icap.conf.in
